### PR TITLE
feat: support base64 google api private keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twistedstream-web",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "twistedstream-web",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@googleapis/drive": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twistedstream-web",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "The web app powering www.twistedstream.com",
   "main": "index.js",

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -115,6 +115,16 @@ test("utils/config", async (t) => {
     });
   });
 
+  t.test("googleAuthPrivateKey (base64)", async (t) => {
+    delete process.env.GOOGLE_AUTH_PRIVATE_KEY;
+    process.env.GOOGLE_AUTH_PRIVATE_KEY_BASE64 = "Z29vZ2xlX0JhbmFuYXMh";
+    const { googleAuthPrivateKey } = importModule(t);
+
+    t.test("is expected value", async (t) => {
+      t.equal(googleAuthPrivateKey, "google_Bananas!");
+    });
+  });
+
   t.test("dataProviderName", async (t) => {
     const { dataProviderName } = importModule(t);
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -22,7 +22,12 @@ export const googleSpreadsheetId = <string>process.env.GOOGLE_SPREADSHEET_ID;
 export const googleAuthClientEmail = <string>(
   process.env.GOOGLE_AUTH_CLIENT_EMAIL
 );
-export const googleAuthPrivateKey = <string>process.env.GOOGLE_AUTH_PRIVATE_KEY;
+export const googleAuthPrivateKey =
+  <string>process.env.GOOGLE_AUTH_PRIVATE_KEY ??
+  Buffer.from(
+    <string>process.env.GOOGLE_AUTH_PRIVATE_KEY_BASE64,
+    "base64"
+  ).toString("utf-8");
 
 export const dataProviderName = <string>process.env.DATA_PROVIDER_NAME;
 export const fileProviderName = <string>process.env.FILE_PROVIDER_NAME;


### PR DESCRIPTION
Allow the `GOOGLE_AUTH_PRIVATE_KEY` env var to be stored as a base64 encoded string since it needs to be multiline and not all environments support multiline env vars.

If using base64, use the `GOOGLE_AUTH_PRIVATE_KEY_BASE64` variable instead.